### PR TITLE
fix CommitPostRelease version in commit message

### DIFF
--- a/src/Release/Task/CommitPostRelease.php
+++ b/src/Release/Task/CommitPostRelease.php
@@ -42,9 +42,10 @@ class CommitPostRelease extends Base
     {
         if (empty($options['next_version'])) {
             if (empty($options['old_version'])) {
-                $options['old_version'] = $this->getComponent()->getVersion();
+                $next_version = $this->getComponent()->getVersion();
+            } else {
+                $next_version = HelperVersion::nextPearVersion($options['old_version']);
             }
-            $next_version = HelperVersion::nextPearVersion($options['old_version']);
         } else {
             $next_version = $options['next_version'];
         }


### PR DESCRIPTION
Doing the CommitPostRelease step after the NextVersion step created a commit message with a version number, that is too high by one.
This should fix that, but it is not clear that all use cases still work with this.